### PR TITLE
Fix Quick Start and Installation Steps: update repository name and copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This repository contains 36 specialized subagents that extend Claude Code's capa
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/claude-code-subagents.git
+git clone https://github.com/davepoon/claude-code-subagents-collection.git
 
 # Copy all subagents to Claude Code's agent directory
-cp claude-code-subagents/*.md ~/.claude/agents/
+cp claude-code-subagents-collection/*.md ~/.claude/agents/
 
 # Restart Claude Code to load the new subagents
 ```

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ cp claude-code-subagents-collection/*.md ~/.claude/agents/
 
 1. **Clone this repository:**
    ```bash
-   git clone https://github.com/yourusername/claude-code-subagents.git
-   cd claude-code-subagents
+   git clone https://github.com/davepoon/claude-code-subagents-collection.git
+   cd claude-code-subagents-collection
    ```
 
 2. **Copy subagents to Claude Code's directory:**


### PR DESCRIPTION
This pull request updates the Quick Start and Installation Steps instructions in the README.md file to use the correct repository name (claude-code-subagents-collection) and copy command.

- The git clone command now matches the actual repository name.
- The copy command uses the correct folder name for subagent files.
- The Installation Steps section is now consistent with the Quick Start instructions.