### PR TITLE
chore: update GitHub Actions workflow for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
+          # Use a Personal Access Token to allow PR creation
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
@@ -44,7 +46,7 @@ jobs:
           title: "chore: release packages"
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Comment on PR


### PR DESCRIPTION
- Added support for using a Personal Access Token for PR creation in the release workflow.
- Updated the GITHUB_TOKEN environment variable to prioritize the RELEASE_TOKEN if available, ensuring better access control during releases.